### PR TITLE
DON'T MERGE: memory update for new S140 SD Version 7

### DIFF
--- a/ld/nrf52840.ld
+++ b/ld/nrf52840.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-  SD (rx) : ORIGIN = 0x00000, LENGTH = 0x26000
-  FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xD0000
+  SD (rx) : ORIGIN = 0x00000, LENGTH = 0x27000
+  FLASH (rx) : ORIGIN = 0x27000, LENGTH = 0xD0000
   RAM (rwx) : ORIGIN = 0x20008000, LENGTH = 0x38000
 }
 OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")

--- a/ld/nrf52840.ld
+++ b/ld/nrf52840.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
   SD (rx) : ORIGIN = 0x00000, LENGTH = 0x27000
-  FLASH (rx) : ORIGIN = 0x27000, LENGTH = 0xD0000
+  FLASH (rx) : ORIGIN = 0x27000, LENGTH = 0xD9000
   RAM (rwx) : ORIGIN = 0x20008000, LENGTH = 0x38000
 }
 OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")

--- a/ld/nrf52840.ld
+++ b/ld/nrf52840.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
   SD (rx) : ORIGIN = 0x00000, LENGTH = 0x27000
-  FLASH (rx) : ORIGIN = 0x27000, LENGTH = 0xD9000
+  FLASH (rx) : ORIGIN = 0x27000, LENGTH = 0xD0000
   RAM (rwx) : ORIGIN = 0x20008000, LENGTH = 0x38000
 }
 OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")

--- a/target-locked.json
+++ b/target-locked.json
@@ -52,6 +52,6 @@
     "linker_flags": "-Wl,--no-wchar-size-warning -Wl,--gc-sections -Wl,--wrap,atexit -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -Wl,--start-group -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -Wl,--end-group", 
     "post_process": "", 
     "processor": "NRF52840", 
-    "snapshot_version": "v1.1.7", 
+    "snapshot_version": "v1.1.10", 
     "toolchain": "ARM_GCC"
 }

--- a/target-locked.json
+++ b/target-locked.json
@@ -52,6 +52,6 @@
     "linker_flags": "-Wl,--no-wchar-size-warning -Wl,--gc-sections -Wl,--wrap,atexit -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -Wl,--start-group -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -Wl,--end-group", 
     "post_process": "", 
     "processor": "NRF52840", 
-    "snapshot_version": "v1.1.10", 
+    "snapshot_version": "v1.1.11", 
     "toolchain": "ARM_GCC"
 }

--- a/target-locked.json
+++ b/target-locked.json
@@ -52,6 +52,6 @@
     "linker_flags": "-Wl,--no-wchar-size-warning -Wl,--gc-sections -Wl,--wrap,atexit -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -Wl,--start-group -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -Wl,--end-group", 
     "post_process": "", 
     "processor": "NRF52840", 
-    "snapshot_version": "v1.1.11", 
+    "snapshot_version": "v1.1.12", 
     "toolchain": "ARM_GCC"
 }


### PR DESCRIPTION
@mmoskal I am trying to update the the codal-nrf52840-dk target to be compatible with Version 7 of the S140 SoftDevice for use with a custom pxt target we are building at @teknikio 

https://tekniverse.teknikio.com/tools/program

There was only a small change to accommodate the new SoftDevice and I was able to build the modified coal-nrf52840-dk target using https://github.com/lancaster-university/codal/ and creating a new target.  

Our pxtarget.json configuration specifies the forked version of this repo in the "compileService" with the memory updates but I am not sure about the "codalBinary":"NRF52840_DK", and "serviceId": "codal2nrf52840".  

Do we need to host the codalBinary somewhere? My understanding was that the codal binary is generated on the fly using the "codalTarget" configuration.  

We are able to deploy and everything builds with the modified codal-nrf52840-dk but I'm pretty sure the application binaries generated by pxt are still being placed at the start address 0x26000 and not 0x27000

Any pointers would be great.  Thanks! 

Also, the current version works great on our custom target as long as we use Version 6 of the S140 SoftDevice.  